### PR TITLE
[e2e/feature-flag]: Flag switcher should turn On and Off the Feature flag if clicking [multiple windows added]

### DIFF
--- a/tests/playwright/e2e/feature-flags/switcher-functionality.spec.ts
+++ b/tests/playwright/e2e/feature-flags/switcher-functionality.spec.ts
@@ -1,8 +1,9 @@
 import { test } from '@playwright/test'
-import { FeatureFlag } from '../../pages'
+import { FeatureFlag, LoginPage } from '../../pages'
 
-test('Flag switcher should turn On and Off the Feature flag if clicking', async ({ page }) => {
+test('Flag switcher should turn On and Off the Feature flag if clicking', async ({ page, context }) => {
   const featureFlagPage = new FeatureFlag(page)
+  const loginPageTab = new LoginPage(await context.newPage())
 
   await featureFlagPage.visitTheFeatureFlagPage()
 
@@ -14,13 +15,11 @@ test('Flag switcher should turn On and Off the Feature flag if clicking', async 
 
   await featureFlagPage.assertTheFlagInLocalStorage()
 
-  await featureFlagPage.clickTheLoginButton()
+  await loginPageTab.visitTheLoginPage()
 
-  await featureFlagPage.assertTheFFlagButtonVisible()
+  await loginPageTab.assertTheFFlagButtonVisible()
 
-  await featureFlagPage.visitTheFeatureFlagPage()
-
-  await page.reload()
+  await featureFlagPage.page.reload()
 
   await featureFlagPage.assertTheFlagInLocalStorage()
 
@@ -28,7 +27,7 @@ test('Flag switcher should turn On and Off the Feature flag if clicking', async 
 
   await featureFlagPage.assertTheFlagNotInStorage()
 
-  await featureFlagPage.clickTheLoginButton()
+  await loginPageTab.page.reload()
 
-  await featureFlagPage.assertFFlagButtonNotVisible()
+  await loginPageTab.assertFFlagButtonNotVisible()
 })

--- a/tests/playwright/pages/index.ts
+++ b/tests/playwright/pages/index.ts
@@ -1,3 +1,4 @@
 export * from './colors.page'
 export * from './example.page'
 export * from './feature-flag.page'
+export * from './login.page'

--- a/tests/playwright/pages/login.page.ts
+++ b/tests/playwright/pages/login.page.ts
@@ -1,0 +1,25 @@
+import { expect, Page, Locator } from '@playwright/test'
+import { GeneralCommands } from './general-commands.page'
+
+export class LoginPage extends GeneralCommands {
+  page: Page
+  featureFlagButton: Locator
+
+  constructor (page: Page) {
+    super(page)
+    this.page = page
+    this.featureFlagButton = page.getByTestId('feature-flag')
+  }
+
+  async visitTheLoginPage () {
+    return this.page.goto('/auth/login')
+  }
+
+  async assertTheFFlagButtonVisible () {
+    await expect(this.featureFlagButton).toBeVisible()
+  }
+
+  async assertFFlagButtonNotVisible () {
+    await expect(this.featureFlagButton).not.toBeVisible()
+  }
+}


### PR DESCRIPTION
**Test refactor**
The tests asserts elements visibility on another tab instead of constantly redirecting to another one

**Files added**
login.page.ts

**Files changed**
[playwright/pages/index]: login page export added

**Vid**
https://user-images.githubusercontent.com/130354469/233340731-53705eb1-50b2-4937-93dc-86de9ef6fea5.mov